### PR TITLE
Swap

### DIFF
--- a/convox.conf
+++ b/convox.conf
@@ -6,4 +6,4 @@ stop on (runlevel [^2345] and net-device-down IFACE=eth0)
 respawn
 respawn limit unlimited
 
-exec docker run -a STDOUT -a STDERR --sig-proxy -e AWS_REGION=$(cat /etc/convox/region) -v /var/run/docker.sock:/var/run/docker.sock convox/agent:0.2
+exec docker run -a STDOUT -a STDERR --sig-proxy -e AWS_REGION=$(cat /etc/convox/region) -v /cgroup:/cgroup -v /var/run/docker.sock:/var/run/docker.sock convox/agent:0.2

--- a/convox.conf
+++ b/convox.conf
@@ -1,0 +1,9 @@
+#!upstart
+
+start on started docker
+stop on (runlevel [^2345] and net-device-down IFACE=eth0)
+
+respawn
+respawn limit unlimited
+
+exec docker run -a STDOUT -a STDERR --sig-proxy -e AWS_REGION=$(cat /etc/convox/region) -v /var/run/docker.sock:/var/run/docker.sock convox/agent:0.2

--- a/monitor.go
+++ b/monitor.go
@@ -96,7 +96,7 @@ func (m *Monitor) handleDie(id string) {
 }
 
 func (m *Monitor) updateCgroups(id string, env map[string]string) {
-	if env["MEMORY_SWAP"] == "0" {
+	if env["SWAP"] == "1" {
 		bytes := "18446744073709551615"
 
 		fmt.Fprintf(os.Stderr, "id=%s cgroup=memory.memsw.limit_in_bytes value=%s\n", id, bytes)

--- a/monitor.go
+++ b/monitor.go
@@ -87,7 +87,7 @@ func (m *Monitor) handleCreate(id string) {
 		}
 	}
 
-	m.setCgroups(id, env)
+	m.updateCgroups(id, env)
 
 	go m.subscribeLogs(id, env["KINESIS"], env["PROCESS"])
 }
@@ -95,24 +95,25 @@ func (m *Monitor) handleCreate(id string) {
 func (m *Monitor) handleDie(id string) {
 }
 
-func (m *Monitor) setCgroups(id string, env map[string]string) {
+func (m *Monitor) updateCgroups(id string, env map[string]string) {
 	if env["MEMORY_SWAP"] == "0" {
 		bytes := "18446744073709551615"
 
-		fmt.Fprintf(os.Stderr, "%s/memory.memsw.limit_in_bytes=%s\n", id, bytes)
-
+		fmt.Fprintf(os.Stderr, "id=%s cgroup=memory.memsw.limit_in_bytes value=%s\n", id, bytes)
 		err := ioutil.WriteFile(fmt.Sprintf("/cgroup/memory/docker/%s/memory.memsw.limit_in_bytes", id), []byte(bytes), 0644)
 
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error: %s\n", err)
 		}
 
+		fmt.Fprintf(os.Stderr, "id=%s cgroup=memory.soft_limit_in_bytes value=%s\n", id, bytes)
 		err = ioutil.WriteFile(fmt.Sprintf("/cgroup/memory/docker/%s/memory.soft_limit_in_bytes", id), []byte(bytes), 0644)
 
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error: %s\n", err)
 		}
 
+		fmt.Fprintf(os.Stderr, "id=%s cgroup=memory.limit_in_bytes value=%s\n", id, bytes)
 		err = ioutil.WriteFile(fmt.Sprintf("/cgroup/memory/docker/%s/memory.limit_in_bytes", id), []byte(bytes), 0644)
 
 		if err != nil {

--- a/monitor.go
+++ b/monitor.go
@@ -97,19 +97,23 @@ func (m *Monitor) handleDie(id string) {
 
 func (m *Monitor) setCgroups(id string, env map[string]string) {
 	if env["MEMORY_SWAP"] == "0" {
-		err := ioutil.WriteFile(fmt.Sprintf("/cgroup/memory/docker/%s/memory.memsw.limit_in_bytes", id), []byte(`18446744073709551615`), 0644)
+		bytes := "18446744073709551615"
+
+		fmt.Fprintf(os.Stderr, "%s/memory.memsw.limit_in_bytes=%s\n", id, bytes)
+
+		err := ioutil.WriteFile(fmt.Sprintf("/cgroup/memory/docker/%s/memory.memsw.limit_in_bytes", id), []byte(bytes), 0644)
 
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error: %s\n", err)
 		}
 
-		err = ioutil.WriteFile(fmt.Sprintf("/cgroup/memory/docker/%s/memory.soft_limit_in_bytes", id), []byte(`18446744073709551615`), 0644)
+		err = ioutil.WriteFile(fmt.Sprintf("/cgroup/memory/docker/%s/memory.soft_limit_in_bytes", id), []byte(bytes), 0644)
 
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error: %s\n", err)
 		}
 
-		err = ioutil.WriteFile(fmt.Sprintf("/cgroup/memory/docker/%s/memory.limit_in_bytes", id), []byte(`18446744073709551615`), 0644)
+		err = ioutil.WriteFile(fmt.Sprintf("/cgroup/memory/docker/%s/memory.limit_in_bytes", id), []byte(bytes), 0644)
 
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error: %s\n", err)


### PR DESCRIPTION
Tune docker memory constraints based off of app environment.

If a container has MEMORY_SWAP=0, set very large memory and swap limits, equivalent to `docker run --memory=0 --memory-swap=0` which indicates there is no memory limit for the container.

https://docs.docker.com/reference/run/#memory-constraints
