### PR TITLE
Enhance logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,10 @@ RUN curl -O https://test.docker.com/builds/Linux/x86_64/docker-1.7.1 && \
     chmod +x docker-1.7.1 && \
     mv docker-1.7.1 /usr/local/bin/docker
 
+RUN go get github.com/ddollar/rerun
+
 WORKDIR /go/src/github.com/convox/agent
 COPY . /go/src/github.com/convox/agent
 RUN go get .
 
 ENV DOCKER_HOST unix:///var/run/docker.sock
-
-ENTRYPOINT ["agent"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,3 +11,5 @@ COPY . /go/src/github.com/convox/agent
 RUN go get .
 
 ENV DOCKER_HOST unix:///var/run/docker.sock
+
+ENTRYPOINT ["agent"]

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,6 @@ vendor:
 	godep save -r -copy=true ./...
 
 release: build
-	docker tag -f convox/agent:latest convox/agent:0.4
-	docker push convox/agent:0.4
-	AWS_DEFAULT_PROFILE=release aws s3 cp convox.conf s3://convox/agent/0.4/convox.conf --acl public-read
+	docker tag -f convox/agent:latest convox/agent:0.5
+	docker push convox/agent:0.5
+	AWS_DEFAULT_PROFILE=release aws s3 cp convox.conf s3://convox/agent/0.5/convox.conf --acl public-read

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ agent | disk monitor upload to=kinesis stream="convox-Kinesis-2NQ3Q5ASHY1N" line
 Run a Docker container to see Docker event Kinesis upload activity:
 
 ```bash
-$ docker run -e KINESIS=convox-Kinesis-2NQ3Q5ASHY1N -e PROCESS=hello-world hello-world
+$ docker run -e KINESIS=convox-Kinesis-2NQ3Q5ASHY1N -e PROCESS=hello-world -e RELEASE=RXBKPDQEGDU hello-world
 ```
 
 ```

--- a/convox.conf
+++ b/convox.conf
@@ -6,4 +6,4 @@ stop on (runlevel [^2345] and net-device-down IFACE=eth0)
 respawn
 respawn limit unlimited
 
-exec docker run -a STDOUT -a STDERR --sig-proxy -e AWS_REGION=$(cat /etc/convox/region) -e KINESIS=$(cat /etc/convox/kinesis) -v /cgroup:/cgroup -v /var/run/docker.sock:/var/run/docker.sock convox/agent:0.4
+exec docker run -a STDOUT -a STDERR --sig-proxy -e AWS_REGION=$(cat /etc/convox/region) -e KINESIS=$(cat /etc/convox/kinesis) -v /cgroup:/cgroup -v /var/run/docker.sock:/var/run/docker.sock convox/agent:0.5

--- a/disk.go
+++ b/disk.go
@@ -105,14 +105,20 @@ func MonitorDmesg() {
 
 // Get an instance identifier
 // On EC2 use the meta-data API to get an instance id
-// Fall back to system hostname if unavailable
+// Fall back to system hostname written in 'i-12345678' style if unavailable
 func GetInstanceId() string {
 	hostname, err := os.Hostname()
 
 	if err != nil {
 		fmt.Printf("error: %s\n", err)
-		hostname = "unknown-host"
+		hostname = "hosterr"
 	}
+
+	if len(hostname) > 8 {
+		hostname = hostname[0:8]
+	}
+
+	hostname = fmt.Sprintf("i-%s", hostname)
 
 	resp, err := http.Get("http://169.254.169.254/latest/meta-data/instance-id")
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,7 @@
 # This is development only. See convox.conf for production upstart config
 agent:
   build: .
-  command: $GOPATH/bin/rerun -build github.com/convox/agent
-  entrypoint:
+  entrypoint: /go/src/github.com/convox/agent/rerun-agent
   environment:
     - AWS_REGION
     - AWS_ACCESS_KEY_ID

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,8 @@
+# This is development only. See convox.conf for production upstart config
 agent:
   build: .
+  command: $GOPATH/bin/rerun -build github.com/convox/agent
+  entrypoint:
   environment:
     - AWS_REGION
     - AWS_ACCESS_KEY_ID
@@ -8,3 +11,4 @@ agent:
   volumes:
     - /cgroup:/cgroup
     - /var/run/docker.sock:/var/run/docker.sock
+    - .:/go/src/github.com/convox/agent

--- a/monitor.go
+++ b/monitor.go
@@ -149,11 +149,11 @@ func (m *Monitor) handleDie(id string) {
 	// While we could remove a container and volumes on this event
 	// It seems like explicitly doing a `docker run --rm` is the best way
 	// to state this intent.
-	m.logEvent(id, fmt.Sprintf("Stopped process %s", id[0:12]))
+	m.logEvent(id, fmt.Sprintf("Dead process %s", id[0:12]))
 }
 
 func (m *Monitor) handleKill(id string) {
-	m.logEvent(id, fmt.Sprintf("Stopping process %s via SIGKILL", id[0:12]))
+	m.logEvent(id, fmt.Sprintf("Stopped process %s via SIGKILL", id[0:12]))
 }
 
 func (m *Monitor) handleStart(id string) {
@@ -161,7 +161,7 @@ func (m *Monitor) handleStart(id string) {
 }
 
 func (m *Monitor) handleStop(id string) {
-	m.logEvent(id, fmt.Sprintf("Stopping process %s via SIGTERM", id[0:12]))
+	m.logEvent(id, fmt.Sprintf("Stopped process %s via SIGTERM", id[0:12]))
 }
 
 func (m *Monitor) inspectContainer(id string) (string, map[string]string, error) {

--- a/monitor.go
+++ b/monitor.go
@@ -233,6 +233,15 @@ func (m *Monitor) subscribeLogs(id, stream, image, process, release string) {
 		return
 	}
 
+	// extract app name from stream
+	// myapp-staging-Kinesis-L6MUKT1VH451 -> myapp-staging
+	app := ""
+
+	parts := strings.Split(stream, "-")
+	if len(parts) > 2 {
+		app = strings.Join(parts[0:len(parts)-2], "-") // drop -Kinesis-YXXX
+	}
+
 	time.Sleep(500 * time.Millisecond)
 
 	r, w := io.Pipe()
@@ -243,7 +252,7 @@ func (m *Monitor) subscribeLogs(id, stream, image, process, release string) {
 		scanner := bufio.NewScanner(r)
 
 		for scanner.Scan() {
-			m.addLine(stream, []byte(fmt.Sprintf("%s %s %s:%s : %s", time.Now().Format("2006-01-02 15:04:05"), m.instanceId, image, release, scanner.Text())))
+			m.addLine(stream, []byte(fmt.Sprintf("%s %s %s/%s:%s : %s", time.Now().Format("2006-01-02 15:04:05"), m.instanceId, app, process, release, scanner.Text())))
 		}
 
 		if scanner.Err() != nil {

--- a/rerun-agent
+++ b/rerun-agent
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/go/bin/rerun -build github.com/convox/agent


### PR DESCRIPTION
Log instance ID, container ID, release ID and additional docker events to the app log stream.

```
^CChappie:agent noah$ convox logs --app httpd
2015-11-21 02:14:46 i-a2eb6f7b convox/agent:0.5 : Starting process ba178922a3fb
2015-11-21 02:14:46 i-a2eb6f7b httpd/web:RDAHGDQMGXP : AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 172.17.0.3. Set the 'ServerName' directive globally to suppress this message
2015-11-21 02:14:46 i-a2eb6f7b httpd/web:RDAHGDQMGXP : AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 172.17.0.3. Set the 'ServerName' directive globally to suppress this message
2015-11-21 02:14:46 i-a2eb6f7b httpd/web:RDAHGDQMGXP : [Sat Nov 21 02:14:46.575330 2015] [mpm_event:notice] [pid 1:tid 140159494530944] AH00489: Apache/2.4.17 (Unix) configured -- resuming normal operations
2015-11-21 02:14:46 i-a2eb6f7b httpd/web:RDAHGDQMGXP : [Sat Nov 21 02:14:46.575450 2015] [core:notice] [pid 1:tid 140159494530944] AH00094: Command line: 'httpd -D FOREGROUND'
2015-11-21 02:15:28 i-a3f60679 httpd/web:RIDVTRGGJEB : AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 172.17.0.5. Set the 'ServerName' directive globally to suppress this message
2015-11-21 02:15:28 i-a3f60679 httpd/web:RIDVTRGGJEB : AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 172.17.0.5. Set the 'ServerName' directive globally to suppress this message
2015-11-21 02:15:28 i-a3f60679 httpd/web:RIDVTRGGJEB : [Sat Nov 21 02:12:08.842821 2015] [mpm_event:notice] [pid 1:tid 139888180590464] AH00489: Apache/2.4.17 (Unix) configured -- resuming normal operations
2015-11-21 02:15:28 i-a3f60679 httpd/web:RIDVTRGGJEB : [Sat Nov 21 02:12:08.842945 2015] [core:notice] [pid 1:tid 139888180590464] AH00094: Command line: 'httpd -D FOREGROUND'
2015-11-21 02:15:28 i-a3f60679 httpd/web:RIDVTRGGJEB : [Sat Nov 21 02:15:28.546170 2015] [mpm_event:notice] [pid 1:tid 139888180590464] AH00491: caught SIGTERM, shutting down
2015-11-21 02:15:28 i-a3f60679 convox/agent:0.5 : Stopped process ebc7bf234805
2015-11-21 02:15:28 i-a3f60679 convox/agent:0.5 : Stopping process ebc7bf234805 via SIGTERM

2015-11-21 02:20:29 i-a3f60679 convox/agent:0.5 : Starting process 9eabcf7d9953
2015-11-21 02:20:29 i-a3f60679 httpd/web:RIDVTRGGJEB : AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 172.17.0.6. Set the 'ServerName' directive globally to suppress this message
2015-11-21 02:20:29 i-a3f60679 httpd/web:RIDVTRGGJEB : AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 172.17.0.6. Set the 'ServerName' directive globally to suppress this message
2015-11-21 02:20:29 i-a3f60679 httpd/web:RIDVTRGGJEB : [Sat Nov 21 02:20:29.257000 2015] [mpm_event:notice] [pid 1:tid 140492121446272] AH00489: Apache/2.4.17 (Unix) configured -- resuming normal operations
2015-11-21 02:20:29 i-a3f60679 httpd/web:RIDVTRGGJEB : [Sat Nov 21 02:20:29.257125 2015] [core:notice] [pid 1:tid 140492121446272] AH00094: Command line: 'httpd -D FOREGROUND'

2015-11-21 02:21:07 i-a2eb6f7b httpd/web:RDAHGDQMGXP : AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 172.17.0.3. Set the 'ServerName' directive globally to suppress this message
2015-11-21 02:21:07 i-a2eb6f7b httpd/web:RDAHGDQMGXP : AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 172.17.0.3. Set the 'ServerName' directive globally to suppress this message
2015-11-21 02:21:07 i-a2eb6f7b httpd/web:RDAHGDQMGXP : [Sat Nov 21 02:14:46.575330 2015] [mpm_event:notice] [pid 1:tid 140159494530944] AH00489: Apache/2.4.17 (Unix) configured -- resuming normal operations
2015-11-21 02:21:07 i-a2eb6f7b httpd/web:RDAHGDQMGXP : [Sat Nov 21 02:14:46.575450 2015] [core:notice] [pid 1:tid 140159494530944] AH00094: Command line: 'httpd -D FOREGROUND'
2015-11-21 02:21:07 i-a2eb6f7b httpd/web:RDAHGDQMGXP : [Sat Nov 21 02:21:07.933693 2015] [mpm_event:notice] [pid 1:tid 140159494530944] AH00491: caught SIGTERM, shutting down
2015-11-21 02:21:07 i-a2eb6f7b convox/agent:0.5 : Stopped process ba178922a3fb
2015-11-21 02:21:08 i-a2eb6f7b convox/agent:0.5 : Stopping process ba178922a3fb via SIGTERM
```

Todo:
- [x] Log container start event
- [x] Design easy to understand inclusion of instance id, container id, or release ID
- [x] Drop docker container id (since instance ID + process name is unique)
- [x] Design and include log timestamps
- [x] Root cause double logging events

Later:
- [ ] Improve docs and CLI around rolling deploy expectations
