### PR TITLE
reword containers logging to better reflect underlying docker events

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -148,30 +148,30 @@ func (m *Monitor) handleDie(id string) {
 	// It seems like explicitly doing a `docker run --rm` is the best way
 	// to state this intent.
 
-	msg := fmt.Sprintf("Dead process %s", id[0:12])
+	msg := fmt.Sprintf("Docker event for process %s - die", id[0:12])
 
 	if p := m.envs[id]["PROCESS"]; p != "" {
-		msg = fmt.Sprintf("Dead %s process %s", p, id[0:12])
+		msg = fmt.Sprintf("Docker event for %s process %s - die", p, id[0:12])
 	}
 
 	m.logAppEvent(id, msg)
 }
 
 func (m *Monitor) handleKill(id string) {
-	msg := fmt.Sprintf("Stopped process %s via SIGKILL", id[0:12])
+	msg := fmt.Sprintf("Docker event for process %s - kill", id[0:12])
 
 	if p := m.envs[id]["PROCESS"]; p != "" {
-		msg = fmt.Sprintf("Stopped %s process %s via SIGKILL", p, id[0:12])
+		msg = fmt.Sprintf("Docker event for %s process %s - kill", p, id[0:12])
 	}
 
 	m.logAppEvent(id, msg)
 }
 
 func (m *Monitor) handleOom(id string) {
-	msg := fmt.Sprintf("Stopped process %s due to OOM", id[0:12])
+	msg := fmt.Sprintf("Docker event for process %s - oom", id[0:12])
 
 	if p := m.envs[id]["PROCESS"]; p != "" {
-		msg = fmt.Sprintf("Stopped %s process %s due to OOM", p, id[0:12])
+		msg = fmt.Sprintf("Docker event for %s process %s - oom", p, id[0:12])
 	}
 
 	m.logAppEvent(id, msg)
@@ -186,10 +186,10 @@ func (m *Monitor) handleStart(id string) {
 }
 
 func (m *Monitor) handleStop(id string) {
-	msg := fmt.Sprintf("Stopped process %s via SIGTERM", id[0:12])
+	msg := fmt.Sprintf("Docker event for process %s - stop", id[0:12])
 
 	if p := m.envs[id]["PROCESS"]; p != "" {
-		msg = fmt.Sprintf("Stopped %s process %s via SIGTERM", p, id[0:12])
+		msg = fmt.Sprintf("Docker event for %s process %s - stop", p, id[0:12])
 	}
 
 	m.logAppEvent(id, msg)


### PR DESCRIPTION
- `kill` does not necessarily map 1-1 to `SIGKILL`
- `stop` does not necessarily map 1-1 to `SIGTERM`

At this point maybe makes more sense to roll the `logAppEvent` call into the outer `handleEvents` function (less boilerplate)?

fixes #19 

We currently see entries like the following when cleanly stopping a container via `convox ps stop` (i.e. via a `SIGTERM`) - 

```
2016-03-10 04:21:48 i-8ecb8f49 convox/agent:0.66 : Stopped web process 88d1fb3c818d via SIGKILL
2016-03-10 04:21:48 i-8ecb8f49 convox/agent:0.66 : Dead web process 88d1fb3c818d
2016-03-10 04:21:48 i-8ecb8f49 convox/agent:0.66 : Stopped web process 88d1fb3c818d via SIGTERM
```
