### PR TITLE
Refactor Towards Log Subscription Perfection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,6 @@ vendor:
 	godep save -r -copy=true ./...
 
 release: build
-	docker tag -f convox/agent:latest convox/agent:0.67
-	docker push convox/agent:0.67
-	AWS_DEFAULT_PROFILE=release aws s3 cp convox.conf s3://convox/agent/0.67/convox.conf --acl public-read
+	docker tag -f convox/agent:latest convox/agent:0.68
+	docker push convox/agent:0.68
+	AWS_DEFAULT_PROFILE=release aws s3 cp convox.conf s3://convox/agent/0.68/convox.conf --acl public-read

--- a/containers.go
+++ b/containers.go
@@ -285,10 +285,10 @@ func (m *Monitor) subscribeLogs(id string) {
 				continue
 			}
 
-		// // Container is missing. Report exception and stop
-		// case docker.NoSuchContainer:
-		// 	m.ReportError(err)
-		// 	break
+		// Container is missing. Report exception and stop
+		case *docker.NoSuchContainer:
+			m.ReportError(err)
+			break
 
 		// Container state is indeterminate. Report exception and retry
 		default:

--- a/containers.go
+++ b/containers.go
@@ -28,6 +28,13 @@ func (m *Monitor) Containers() {
 	go m.handleEvents(ch)
 	go m.streamLogs()
 
+	// HACK: Range over instrumentation messages channel added to awslogs package
+	go func() {
+		for msg := range awslogs.ConvoxSystemMessages {
+			m.logSystemf(msg)
+		}
+	}()
+
 	m.client.AddEventListener(ch)
 }
 

--- a/convox.conf
+++ b/convox.conf
@@ -13,4 +13,4 @@ exec docker run -a STDOUT -a STDERR --sig-proxy \
   -v /:/mnt/host_root                           \
   -v /cgroup:/cgroup                            \
   -v /var/run/docker.sock:/var/run/docker.sock  \
-  convox/agent:0.67
+  convox/agent:0.68

--- a/convox.conf
+++ b/convox.conf
@@ -8,6 +8,7 @@ respawn limit unlimited
 
 exec docker run -a STDOUT -a STDERR --sig-proxy \
   -e AWS_REGION=$(cat /etc/convox/region)       \
+  -e CLIENT_ID=$(cat /etc/convox/client_id)     \
   -e KINESIS=$(cat /etc/convox/kinesis)         \
   -e LOG_GROUP=$(cat /etc/convox/log_group)     \
   -v /:/mnt/host_root                           \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,11 @@ agent:
     - AWS_REGION
     - AWS_ACCESS_KEY_ID
     - AWS_SECRET_ACCESS_KEY
+    - CLIENT_ID=dev@convox.com
     - KINESIS
     - LOG_GROUP
     - DEVELOPMENT=true
   volumes:
-    - /:/mnt/host_root
+    - /tmp:/mnt/host_root
     - /sys/fs/cgroup:/cgroup
     - /var/run/docker.sock:/var/run/docker.sock
-    - .:/go/src/github.com/convox/agent

--- a/docker.go
+++ b/docker.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os/exec"
 	"time"
 )
@@ -11,19 +10,19 @@ import (
 // if it returns normally once, consider the system healthy
 // if it hangs for >30s every time, consider the system unhealthy
 func (m *Monitor) Docker() {
-	m.logSystemMetric("docker at=start", "", true)
+	m.logSystemf("docker at=start")
 
 	for _ = range time.Tick(MONITOR_INTERVAL) {
 		var err error
 		unhealthy := true
 
 		for i := 0; i < 5; i++ {
-			fmt.Printf("docker try=%d\n", i)
+			m.logSystemf("docker exec.Command args=ps try=%d", i)
 
 			cmd := exec.Command("docker", "ps")
 
 			if err := cmd.Start(); err != nil {
-				m.logSystemMetric("docker at=error", fmt.Sprintf("count#DockerCommandStart.error=1 err=%q", err), true)
+				m.logSystemf("docker exec.Command args=ps try=%d count#DockerPsError=1 err=%q", i, err)
 				continue
 			}
 
@@ -45,7 +44,7 @@ func (m *Monitor) Docker() {
 		if unhealthy {
 			m.SetUnhealthy("docker", err)
 		} else {
-			m.logSystemMetric("docker at=ok", "", true)
+			m.logSystemf("docker ok=true")
 		}
 	}
 }

--- a/monitor.go
+++ b/monitor.go
@@ -184,6 +184,7 @@ func (m *Monitor) ReportError(err error) {
 	m.logSystemMetric("monitor at=error", fmt.Sprintf("err=%q", err), true)
 
 	rollbar.Token = "f67f25b8a9024d5690f997bd86bf14b0"
+	rollbar.Token = "366f5bdd094f42a0be6259af715354f2"
 
 	extraData := map[string]string{
 		"agentId":    m.agentId,

--- a/monitor.go
+++ b/monitor.go
@@ -181,6 +181,8 @@ func (m *Monitor) ReportError(err error) {
 		"agentId":    m.agentId,
 		"agentImage": m.agentImage,
 
+		"clientId": os.Getenv("CLIENT_ID"),
+
 		"amiId":        m.amiId,
 		"az":           m.az,
 		"instanceId":   m.instanceId,
@@ -194,7 +196,7 @@ func (m *Monitor) ReportError(err error) {
 	}
 	extraField := &rollbar.Field{"env", extraData}
 
-	rollbar.Error(rollbar.CRIT, err, extraField)
+	rollbar.ErrorWithStackSkip(rollbar.CRIT, err, 1, extraField)
 }
 
 func (m *Monitor) SetUnhealthy(system string, reason error) {

--- a/monitor.go
+++ b/monitor.go
@@ -175,7 +175,7 @@ func GetECSAgentImage(client *docker.Client) (string, error) {
 func (m *Monitor) ReportError(err error) {
 	m.logSystemf("monitor ReportError err=%q", err)
 
-	rollbar.Token = "366f5bdd094f42a0be6259af715354f2"
+	rollbar.Token = "ca01e8fc13ed4aa893f7a0300d94f2e1"
 
 	extraData := map[string]string{
 		"agentId":    m.agentId,

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -125,8 +125,9 @@ func TestNewMonitor(t *testing.T) {
 
 			envs: make(map[string]map[string]string),
 
-			agentId:    "unknown",
-			agentImage: "convox/agent:dev",
+			agentId:      "unknown",
+			agentImage:   "convox/agent:dev",
+			agentVersion: "dev",
 
 			amiId:        "ami-cb2305a1",
 			az:           "us-east-1c",

--- a/vendor/github.com/docker/docker/daemon/logger/awslogs/cloudwatchlogs.go
+++ b/vendor/github.com/docker/docker/daemon/logger/awslogs/cloudwatchlogs.go
@@ -57,7 +57,7 @@ type logStream struct {
 
 /// CONVOX HACK!
 
-var ConvoxSystemMessages = make(chan string, 10)
+var ConvoxSystemMessages = make(chan string, 100)
 
 // logSystemf is used to instrument this library
 // It facilitates putting additional info on agent stdout and the Rack CloudWatch LogGroup


### PR DESCRIPTION
This is available for testing with `convox rack update 20160420210148-agent-0.68`

Paired up with @awsmsrc to lick the problem where log the subscribers failed and never recovered, taking individual process logs offline until a restart.
- Refactor/rewrite subscribeLogs with much better Go concurrency and synchronization patterns
- Log with metrics around lines read from Docker (metric: Lines)
- Instrument, and log with metrics around events written to CloudWatch  (metric: CloudWatchEventsSuccesses / CloudWatchEventsErrors)
- Normalize logging everywhere and add logging to to make it easier to understand in development
- Send all agent logs to the Rack LogGroup to better understand / debug and visualize in production
- Stop sending agent logs to the Rack Kinesis

This is a release candidate, though we could consider dialing down logs a bit before releasing this. I'll make a judgement call after some production instance hours.

<img width="467" alt="screen shot 2016-04-20 at 4 08 53 pm" src="https://cloud.githubusercontent.com/assets/147410/14693269/349224a0-0712-11e6-85d9-70fedfb34fa0.png">
