### PR TITLE
Name agent container

### DIFF
--- a/convox.conf
+++ b/convox.conf
@@ -6,12 +6,12 @@ stop on (runlevel [^2345] and net-device-down IFACE=eth0)
 respawn
 respawn limit unlimited
 
-exec docker run -a STDOUT -a STDERR --sig-proxy \
-  -e AWS_REGION=$(cat /etc/convox/region)       \
-  -e CLIENT_ID=$(cat /etc/convox/client_id)     \
-  -e KINESIS=$(cat /etc/convox/kinesis)         \
-  -e LOG_GROUP=$(cat /etc/convox/log_group)     \
-  -v /:/mnt/host_root                           \
-  -v /cgroup:/cgroup                            \
-  -v /var/run/docker.sock:/var/run/docker.sock  \
+exec docker run -a STDOUT -a STDERR --sig-proxy --name convox-agent \
+  -e AWS_REGION=$(cat /etc/convox/region)                           \
+  -e CLIENT_ID=$(cat /etc/convox/client_id)                         \
+  -e KINESIS=$(cat /etc/convox/kinesis)                             \
+  -e LOG_GROUP=$(cat /etc/convox/log_group)                         \
+  -v /:/mnt/host_root                                               \
+  -v /cgroup:/cgroup                                                \
+  -v /var/run/docker.sock:/var/run/docker.sock                      \
   convox/agent:0.70


### PR DESCRIPTION
Set name as `convox-agent` for improved ease of use when comparing containers on a rack.

Replaces #23.
