### PR TITLE
check for LOG_GROUP before subscribing to logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,6 @@ vendor:
 	godep save -r -copy=true ./...
 
 release: build
-	docker tag convox/agent:latest convox/agent:0.72
-	docker push convox/agent:0.72
-	AWS_DEFAULT_PROFILE=release aws s3 cp convox.conf s3://convox/agent/0.72/convox.conf --acl public-read
+	docker tag convox/agent:latest convox/agent:0.73
+	docker push convox/agent:0.73
+	AWS_DEFAULT_PROFILE=release aws s3 cp convox.conf s3://convox/agent/0.73/convox.conf --acl public-read

--- a/containers.go
+++ b/containers.go
@@ -227,7 +227,11 @@ func (m *Monitor) handleStart(id string) {
 	m.updateCgroups(id)
 
 	if id != m.agentId {
-		m.subscribeLogs(id)
+		if env, ok := m.getEnv(id); ok {
+			if env["LOG_GROUP"] != "" {
+				m.subscribeLogs(id)
+			}
+		}
 	}
 
 	m.logSystemf("container handleStart at=end id=%s", id)

--- a/convox.conf
+++ b/convox.conf
@@ -14,4 +14,4 @@ exec docker run -a STDOUT -a STDERR --sig-proxy \
   -v /:/mnt/host_root                           \
   -v /cgroup:/cgroup                            \
   -v /var/run/docker.sock:/var/run/docker.sock  \
-  convox/agent:0.72
+  convox/agent:0.73


### PR DESCRIPTION
Addresses https://github.com/convox/rack/issues/2133

This prevents containers of apps on the `NativeLogging=Yes` parameter causing additional CPU load.

It was observed that the subscribeLogs path was entered for containers with no LOG_GROUP, which causes the agent to spin on trying to read and forward logs. It should be ignoring these containers completely.

```
{"log":"agent:0.70/i-**** container subscribeLogs id=dc798b51eba9e631e29cc8b7327862191f23533d146a572bae1e3ff29bc1421f count#DockerLogsRetry=1\n","stream":"stdout","time":"2017-04-09T17:37:21.036966047Z"}
{"log":"agent:0.70/i-**** container subscribeLogs followDockerLogs id=dc798b51eba9e631e29cc8b7327862191f23533d146a572bae1e3ff29bc1421f at=start\n","stream":"stdout","time":"2017-04-09T17:37:21.036980654Z"}
{"log":"agent:0.70/i-**** container subscribeLogs readLines id=dc798b51eba9e631e29cc8b7327862191f23533d146a572bae1e3ff29bc1421f at=start\n","stream":"stdout","time":"2017-04-09T17:37:21.036985268Z"}
```